### PR TITLE
Add midpoint to bylaw

### DIFF
--- a/parking/tests/test_models.py
+++ b/parking/tests/test_models.py
@@ -97,6 +97,13 @@ class ByLawModelTest(TestCase):
         field_label = law._meta.get_field("max_period_permitted").verbose_name
         self.assertEqual(field_label, "max period permitted")
 
+    def test_midpoint(self):
+        law = ByLaw.objects.get(id=1)
+        midpoint_a = (self.intersection_1.lat + self.intersection_2.lat) / 2
+        midpoint_b = (self.intersection_1.lng + self.intersection_2.lng) / 2
+        self.assertEqual(law.midpoint[0], midpoint_a)
+        self.assertEqual(law.midpoint[1], midpoint_b)
+
 
 class HighwayModelTest(TestCase):
     @classmethod

--- a/parking/whereToPark/models.py
+++ b/parking/whereToPark/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.db.models import Q
+from django.utils.functional import cached_property
 
 
 STREET_SIDES = (("W", "West"), ("E", "East"), ("N", "North"), ("S", "South"))
@@ -101,6 +102,20 @@ class ByLaw(models.Model):
 
     def __str__(self):
         return f"{self.highway} ({self.side}) - {self.source_id}"
+
+    @cached_property
+    def midpoint(self):
+        if not self.boundary_start or not self.boundary_end:
+            return (None, None)
+        lat_mid = (self.boundary_start.lat + self.boundary_end.lat) / 2
+        lng_mid = (self.boundary_start.lng + self.boundary_end.lng) / 2
+        return (lat_mid, lng_mid)
+
+    @cached_property
+    def popup_html(self):
+        html = f"<h1>ByLaw</h1><br/><h3>{self.highway} at {self.between}</h3>"
+        print(html)
+        return html
 
     class Meta:
         unique_together = ["schedule", "source_id"]

--- a/parking/whereToPark/models.py
+++ b/parking/whereToPark/models.py
@@ -111,12 +111,6 @@ class ByLaw(models.Model):
         lng_mid = (self.boundary_start.lng + self.boundary_end.lng) / 2
         return (lat_mid, lng_mid)
 
-    @cached_property
-    def popup_html(self):
-        html = f"<h1>ByLaw</h1><br/><h3>{self.highway} at {self.between}</h3>"
-        print(html)
-        return html
-
     class Meta:
         unique_together = ["schedule", "source_id"]
 

--- a/parking/whereToPark/templates/whereToPark/index.html
+++ b/parking/whereToPark/templates/whereToPark/index.html
@@ -10,9 +10,6 @@
 </head>
 <body style="overflow: hidden">
     <div style="width: 100vw;height:100vh;position: static;" id='map'></div>
-    <!-- {% for bylaw in np_bylaws %}
-        <div> {{ bylaw.boundary_start.lat }}</div></br>
-    {% endfor %} -->
     <script>
 
         let currentEventMarkers = [];
@@ -34,10 +31,7 @@
         let coord_b;
         let coord_mid;
         let marker_mid;
-        let popup;
         {% for bylaw in rp_bylaws %}
-            // popup = new mapboxgl.Popup({ closeOnClick: false })
-            //     .setHTML({{ bylaw.popup_html }})
             coord_a = [{{ bylaw.boundary_start.lng }}, {{ bylaw.boundary_start.lat }} ]
             coord_b = [{{ bylaw.boundary_end.lng }}, {{ bylaw.boundary_end.lat }} ]
             coord_mid = [{{ bylaw.midpoint.1 }}, {{ bylaw.midpoint.0 }} ]
@@ -48,13 +42,10 @@
                 .setLngLat(coord_b)
                 .addTo(map);
             marker_mid = new mapboxgl.Marker({ color: "#FFA500" })
-                .setPopup(popup)
                 .setLngLat(coord_mid)
                 .addTo(map);
         {% endfor %}
         {% for bylaw in np_bylaws %}
-            // popup = new mapboxgl.Popup({ closeOnClick: false })
-            //     .setHTML({{ bylaw.popup_html }})
             coord_a = [{{ bylaw.boundary_start.lng }}, {{ bylaw.boundary_start.lat }} ]
             coord_b = [{{ bylaw.boundary_end.lng }}, {{ bylaw.boundary_end.lat }} ]
             coord_mid = [{{ bylaw.midpoint.1 }}, {{ bylaw.midpoint.0 }} ]
@@ -65,7 +56,6 @@
                 .setLngLat(coord_b)
                 .addTo(map);
             marker_mid = new mapboxgl.Marker({ color: "#FFA500" })
-                .setPopup(popup)
                 .setLngLat(coord_mid)
                 .addTo(map);
         {% endfor %}

--- a/parking/whereToPark/templates/whereToPark/index.html
+++ b/parking/whereToPark/templates/whereToPark/index.html
@@ -32,24 +32,41 @@
         let marker_b;
         let coord_a;
         let coord_b;
+        let coord_mid;
+        let marker_mid;
+        let popup;
         {% for bylaw in rp_bylaws %}
+            // popup = new mapboxgl.Popup({ closeOnClick: false })
+            //     .setHTML({{ bylaw.popup_html }})
             coord_a = [{{ bylaw.boundary_start.lng }}, {{ bylaw.boundary_start.lat }} ]
             coord_b = [{{ bylaw.boundary_end.lng }}, {{ bylaw.boundary_end.lat }} ]
+            coord_mid = [{{ bylaw.midpoint.1 }}, {{ bylaw.midpoint.0 }} ]
             marker_a = new mapboxgl.Marker({ color: "#50C878" })
                 .setLngLat(coord_a)
                 .addTo(map);
             marker_b = new mapboxgl.Marker({ color: "#50C878" })
                 .setLngLat(coord_b)
                 .addTo(map);
+            marker_mid = new mapboxgl.Marker({ color: "#FFA500" })
+                .setPopup(popup)
+                .setLngLat(coord_mid)
+                .addTo(map);
         {% endfor %}
         {% for bylaw in np_bylaws %}
+            // popup = new mapboxgl.Popup({ closeOnClick: false })
+            //     .setHTML({{ bylaw.popup_html }})
             coord_a = [{{ bylaw.boundary_start.lng }}, {{ bylaw.boundary_start.lat }} ]
             coord_b = [{{ bylaw.boundary_end.lng }}, {{ bylaw.boundary_end.lat }} ]
+            coord_mid = [{{ bylaw.midpoint.1 }}, {{ bylaw.midpoint.0 }} ]
             marker_a = new mapboxgl.Marker({ color: "#ff0000" })
                 .setLngLat(coord_a)
                 .addTo(map);
             marker_b = new mapboxgl.Marker({ color: "#ff0000" })
                 .setLngLat(coord_b)
+                .addTo(map);
+            marker_mid = new mapboxgl.Marker({ color: "#FFA500" })
+                .setPopup(popup)
+                .setLngLat(coord_mid)
                 .addTo(map);
         {% endfor %}
         }


### PR DESCRIPTION
This PR adds a midpoint property to the `ByLaw` model so that we can display the marker as a midpoint between start and end boundaries.